### PR TITLE
[#10] Improve versionedRelease output in record

### DIFF
--- a/fictional-example/record/ocds-213czf-000-00001.json
+++ b/fictional-example/record/ocds-213czf-000-00001.json
@@ -453,34 +453,42 @@
                   "contractPeriod": {
                      "endDate": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2010-05-10",
+                           "releaseID": "ocds-213czf-000-00001-04-award",
+                           "releaseTag": [
+                              "award"
+                           ],
                            "value": "2011-08-01"
                         }
                      ],
                      "startDate": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2010-05-10",
+                           "releaseID": "ocds-213czf-000-00001-04-award",
+                           "releaseTag": [
+                              "award"
+                           ],
                            "value": "2010-07-01"
                         }
                      ]
                   },
                   "date": [
                      {
-                        "releaseDate": null,
-                        "releaseID": null,
-                        "releaseTag": null,
+                        "releaseDate": "2010-05-10",
+                        "releaseID": "ocds-213czf-000-00001-04-award",
+                        "releaseTag": [
+                           "award"
+                        ],
                         "value": "2010-05-10"
                      }
                   ],
                   "description": [
                      {
-                        "releaseDate": null,
-                        "releaseID": null,
-                        "releaseTag": null,
+                        "releaseDate": "2010-05-10",
+                        "releaseID": "ocds-213czf-000-00001-04-award",
+                        "releaseTag": [
+                           "award"
+                        ],
                         "value": "AnyCorp Ltd has been awarded the contract to build new cycle lanes in the centre of town."
                      }
                   ],
@@ -488,58 +496,72 @@
                      {
                         "datePublished": [
                            {
-                              "releaseDate": null,
-                              "releaseID": null,
-                              "releaseTag": null,
+                              "releaseDate": "2010-05-10",
+                              "releaseID": "ocds-213czf-000-00001-04-award",
+                              "releaseTag": [
+                                 "award"
+                              ],
                               "value": "2010-05-10"
                            }
                         ],
                         "description": [
                            {
-                              "releaseDate": null,
-                              "releaseID": null,
-                              "releaseTag": null,
+                              "releaseDate": "2010-05-10",
+                              "releaseID": "ocds-213czf-000-00001-04-award",
+                              "releaseTag": [
+                                 "award"
+                              ],
                               "value": "Award of contract to build new cycle lanes in the centre of town to AnyCorp Ltd."
                            }
                         ],
                         "documentType": [
                            {
-                              "releaseDate": null,
-                              "releaseID": null,
-                              "releaseTag": null,
+                              "releaseDate": "2010-05-10",
+                              "releaseID": "ocds-213czf-000-00001-04-award",
+                              "releaseTag": [
+                                 "award"
+                              ],
                               "value": "notice"
                            }
                         ],
                         "format": [
                            {
-                              "releaseDate": null,
-                              "releaseID": null,
-                              "releaseTag": null,
+                              "releaseDate": "2010-05-10",
+                              "releaseID": "ocds-213czf-000-00001-04-award",
+                              "releaseTag": [
+                                 "award"
+                              ],
                               "value": "text/html"
                            }
                         ],
                         "id": "0007",
                         "language": [
                            {
-                              "releaseDate": null,
-                              "releaseID": null,
-                              "releaseTag": null,
+                              "releaseDate": "2010-05-10",
+                              "releaseID": "ocds-213czf-000-00001-04-award",
+                              "releaseTag": [
+                                 "award"
+                              ],
                               "value": "en"
                            }
                         ],
                         "title": [
                            {
-                              "releaseDate": null,
-                              "releaseID": null,
-                              "releaseTag": null,
+                              "releaseDate": "2010-05-10",
+                              "releaseID": "ocds-213czf-000-00001-04-award",
+                              "releaseTag": [
+                                 "award"
+                              ],
                               "value": "Award notice"
                            }
                         ],
                         "url": [
                            {
-                              "releaseDate": null,
-                              "releaseID": null,
-                              "releaseTag": null,
+                              "releaseDate": "2010-05-10",
+                              "releaseID": "ocds-213czf-000-00001-04-award",
+                              "releaseTag": [
+                                 "award"
+                              ],
                               "value": "http://example.com/tender-notices/ocds-213czf-000-00001-04.html"
                            }
                         ]
@@ -550,9 +572,11 @@
                      {
                         "additionalClassifications": [
                            {
-                              "releaseDate": null,
-                              "releaseID": null,
-                              "releaseTag": null,
+                              "releaseDate": "2010-05-10",
+                              "releaseID": "ocds-213czf-000-00001-04-award",
+                              "releaseTag": [
+                                 "award"
+                              ],
                               "value": [
                                  {
                                     "description": "Cycle path construction work",
@@ -566,77 +590,95 @@
                         "classification": {
                            "description": [
                               {
-                                 "releaseDate": null,
-                                 "releaseID": null,
-                                 "releaseTag": null,
+                                 "releaseDate": "2010-05-10",
+                                 "releaseID": "ocds-213czf-000-00001-04-award",
+                                 "releaseTag": [
+                                    "award"
+                                 ],
                                  "value": "Construction work for highways"
                               }
                            ],
                            "id": [
                               {
-                                 "releaseDate": null,
-                                 "releaseID": null,
-                                 "releaseTag": null,
+                                 "releaseDate": "2010-05-10",
+                                 "releaseID": "ocds-213czf-000-00001-04-award",
+                                 "releaseTag": [
+                                    "award"
+                                 ],
                                  "value": "45233130"
                               }
                            ],
                            "scheme": [
                               {
-                                 "releaseDate": null,
-                                 "releaseID": null,
-                                 "releaseTag": null,
+                                 "releaseDate": "2010-05-10",
+                                 "releaseID": "ocds-213czf-000-00001-04-award",
+                                 "releaseTag": [
+                                    "award"
+                                 ],
                                  "value": "CPV"
                               }
                            ],
                            "uri": [
                               {
-                                 "releaseDate": null,
-                                 "releaseID": null,
-                                 "releaseTag": null,
+                                 "releaseDate": "2010-05-10",
+                                 "releaseID": "ocds-213czf-000-00001-04-award",
+                                 "releaseTag": [
+                                    "award"
+                                 ],
                                  "value": "http://cpv.data.ac.uk/code-45233130"
                               }
                            ]
                         },
                         "description": [
                            {
-                              "releaseDate": null,
-                              "releaseID": null,
-                              "releaseTag": null,
+                              "releaseDate": "2010-05-10",
+                              "releaseID": "ocds-213czf-000-00001-04-award",
+                              "releaseTag": [
+                                 "award"
+                              ],
                               "value": "string"
                            }
                         ],
                         "id": "0001",
                         "quantity": [
                            {
-                              "releaseDate": null,
-                              "releaseID": null,
-                              "releaseTag": null,
+                              "releaseDate": "2010-05-10",
+                              "releaseID": "ocds-213czf-000-00001-04-award",
+                              "releaseTag": [
+                                 "award"
+                              ],
                               "value": 8
                            }
                         ],
                         "unit": {
                            "name": [
                               {
-                                 "releaseDate": null,
-                                 "releaseID": null,
-                                 "releaseTag": null,
+                                 "releaseDate": "2010-05-10",
+                                 "releaseID": "ocds-213czf-000-00001-04-award",
+                                 "releaseTag": [
+                                    "award"
+                                 ],
                                  "value": "Miles"
                               }
                            ],
                            "value": {
                               "amount": [
                                  {
-                                    "releaseDate": null,
-                                    "releaseID": null,
-                                    "releaseTag": null,
+                                    "releaseDate": "2010-05-10",
+                                    "releaseID": "ocds-213czf-000-00001-04-award",
+                                    "releaseTag": [
+                                       "award"
+                                    ],
                                     "value": 137000
                                  }
                               ],
                               "currency": [
                                  {
-                                    "releaseDate": null,
-                                    "releaseID": null,
-                                    "releaseTag": null,
+                                    "releaseDate": "2010-05-10",
+                                    "releaseID": "ocds-213czf-000-00001-04-award",
+                                    "releaseTag": [
+                                       "award"
+                                    ],
                                     "value": "GBP"
                                  }
                               ]
@@ -646,23 +688,29 @@
                   ],
                   "status": [
                      {
-                        "releaseDate": null,
-                        "releaseID": null,
-                        "releaseTag": null,
+                        "releaseDate": "2010-05-10",
+                        "releaseID": "ocds-213czf-000-00001-04-award",
+                        "releaseTag": [
+                           "award"
+                        ],
                         "value": "pending"
                      },
                      {
-                        "releaseDate": null,
-                        "releaseID": null,
-                        "releaseTag": null,
+                        "releaseDate": "2010-05-10",
+                        "releaseID": "ocds-213czf-000-00001-05-contract",
+                        "releaseTag": [
+                           "contract"
+                        ],
                         "value": "active"
                      }
                   ],
                   "suppliers": [
                      {
-                        "releaseDate": null,
-                        "releaseID": null,
-                        "releaseTag": null,
+                        "releaseDate": "2010-05-10",
+                        "releaseID": "ocds-213czf-000-00001-04-award",
+                        "releaseTag": [
+                           "award"
+                        ],
                         "value": [
                            {
                               "additionalIdentifiers": [
@@ -697,26 +745,32 @@
                   ],
                   "title": [
                      {
-                        "releaseDate": null,
-                        "releaseID": null,
-                        "releaseTag": null,
+                        "releaseDate": "2010-05-10",
+                        "releaseID": "ocds-213czf-000-00001-04-award",
+                        "releaseTag": [
+                           "award"
+                        ],
                         "value": "Award of contract to build new cycle lanes in the centre of town."
                      }
                   ],
                   "value": {
                      "amount": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2010-05-10",
+                           "releaseID": "ocds-213czf-000-00001-04-award",
+                           "releaseTag": [
+                              "award"
+                           ],
                            "value": 11000000
                         }
                      ],
                      "currency": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2010-05-10",
+                           "releaseID": "ocds-213czf-000-00001-04-award",
+                           "releaseTag": [
+                              "award"
+                           ],
                            "value": "GBP"
                         }
                      ]
@@ -727,41 +781,51 @@
                "address": {
                   "countryName": [
                      {
-                        "releaseDate": null,
-                        "releaseID": null,
-                        "releaseTag": null,
+                        "releaseDate": "2009-03-15",
+                        "releaseID": "ocds-213czf-000-00001-01-planning",
+                        "releaseTag": [
+                           "planning"
+                        ],
                         "value": "United Kingdom"
                      }
                   ],
                   "locality": [
                      {
-                        "releaseDate": null,
-                        "releaseID": null,
-                        "releaseTag": null,
+                        "releaseDate": "2009-03-15",
+                        "releaseID": "ocds-213czf-000-00001-01-planning",
+                        "releaseTag": [
+                           "planning"
+                        ],
                         "value": "London"
                      }
                   ],
                   "postalCode": [
                      {
-                        "releaseDate": null,
-                        "releaseID": null,
-                        "releaseTag": null,
+                        "releaseDate": "2009-03-15",
+                        "releaseID": "ocds-213czf-000-00001-01-planning",
+                        "releaseTag": [
+                           "planning"
+                        ],
                         "value": "N11 1NP"
                      }
                   ],
                   "region": [
                      {
-                        "releaseDate": null,
-                        "releaseID": null,
-                        "releaseTag": null,
+                        "releaseDate": "2009-03-15",
+                        "releaseID": "ocds-213czf-000-00001-01-planning",
+                        "releaseTag": [
+                           "planning"
+                        ],
                         "value": "London"
                      }
                   ],
                   "streetAddress": [
                      {
-                        "releaseDate": null,
-                        "releaseID": null,
-                        "releaseTag": null,
+                        "releaseDate": "2009-03-15",
+                        "releaseID": "ocds-213czf-000-00001-01-planning",
+                        "releaseTag": [
+                           "planning"
+                        ],
                         "value": "4, North London Business Park, Oakleigh Rd S"
                      }
                   ]
@@ -769,41 +833,51 @@
                "contactPoint": {
                   "email": [
                      {
-                        "releaseDate": null,
-                        "releaseID": null,
-                        "releaseTag": null,
+                        "releaseDate": "2009-03-15",
+                        "releaseID": "ocds-213czf-000-00001-01-planning",
+                        "releaseTag": [
+                           "planning"
+                        ],
                         "value": "procurement-team@example.com"
                      }
                   ],
                   "faxNumber": [
                      {
-                        "releaseDate": null,
-                        "releaseID": null,
-                        "releaseTag": null,
+                        "releaseDate": "2009-03-15",
+                        "releaseID": "ocds-213czf-000-00001-01-planning",
+                        "releaseTag": [
+                           "planning"
+                        ],
                         "value": "01234 345 345"
                      }
                   ],
                   "name": [
                      {
-                        "releaseDate": null,
-                        "releaseID": null,
-                        "releaseTag": null,
+                        "releaseDate": "2009-03-15",
+                        "releaseID": "ocds-213czf-000-00001-01-planning",
+                        "releaseTag": [
+                           "planning"
+                        ],
                         "value": "Procurement Team"
                      }
                   ],
                   "telephone": [
                      {
-                        "releaseDate": null,
-                        "releaseID": null,
-                        "releaseTag": null,
+                        "releaseDate": "2009-03-15",
+                        "releaseID": "ocds-213czf-000-00001-01-planning",
+                        "releaseTag": [
+                           "planning"
+                        ],
                         "value": "01234 345 346"
                      }
                   ],
                   "url": [
                      {
-                        "releaseDate": null,
-                        "releaseID": null,
-                        "releaseTag": null,
+                        "releaseDate": "2009-03-15",
+                        "releaseID": "ocds-213czf-000-00001-01-planning",
+                        "releaseTag": [
+                           "planning"
+                        ],
                         "value": "http://example.com/contact/"
                      }
                   ]
@@ -811,42 +885,52 @@
                "identifier": {
                   "id": [
                      {
-                        "releaseDate": null,
-                        "releaseID": null,
-                        "releaseTag": null,
+                        "releaseDate": "2009-03-15",
+                        "releaseID": "ocds-213czf-000-00001-01-planning",
+                        "releaseTag": [
+                           "planning"
+                        ],
                         "value": "E09000003"
                      }
                   ],
                   "legalName": [
                      {
-                        "releaseDate": null,
-                        "releaseID": null,
-                        "releaseTag": null,
+                        "releaseDate": "2009-03-15",
+                        "releaseID": "ocds-213czf-000-00001-01-planning",
+                        "releaseTag": [
+                           "planning"
+                        ],
                         "value": "London Borough of Barnet"
                      }
                   ],
                   "scheme": [
                      {
-                        "releaseDate": null,
-                        "releaseID": null,
-                        "releaseTag": null,
+                        "releaseDate": "2009-03-15",
+                        "releaseID": "ocds-213czf-000-00001-01-planning",
+                        "releaseTag": [
+                           "planning"
+                        ],
                         "value": "GB-LAC"
                      }
                   ],
                   "uri": [
                      {
-                        "releaseDate": null,
-                        "releaseID": null,
-                        "releaseTag": null,
+                        "releaseDate": "2009-03-15",
+                        "releaseID": "ocds-213czf-000-00001-01-planning",
+                        "releaseTag": [
+                           "planning"
+                        ],
                         "value": "http://www.barnet.gov.uk/"
                      }
                   ]
                },
                "name": [
                   {
-                     "releaseDate": null,
-                     "releaseID": null,
-                     "releaseTag": null,
+                     "releaseDate": "2009-03-15",
+                     "releaseID": "ocds-213czf-000-00001-01-planning",
+                     "releaseTag": [
+                        "planning"
+                     ],
                      "value": "London Borough of Barnet"
                   }
                ]
@@ -855,31 +939,39 @@
                {
                   "awardID": [
                      {
-                        "releaseDate": null,
-                        "releaseID": null,
-                        "releaseTag": null,
+                        "releaseDate": "2010-05-10",
+                        "releaseID": "ocds-213czf-000-00001-05-contract",
+                        "releaseTag": [
+                           "contract"
+                        ],
                         "value": "ocds-213czf-000-00001-award-01"
                      }
                   ],
                   "dateSigned": [
                      {
-                        "releaseDate": null,
-                        "releaseID": null,
-                        "releaseTag": null,
+                        "releaseDate": "2010-05-10",
+                        "releaseID": "ocds-213czf-000-00001-05-contract",
+                        "releaseTag": [
+                           "contract"
+                        ],
                         "value": "2015-06-10"
                      }
                   ],
                   "description": [
                      {
-                        "releaseDate": null,
-                        "releaseID": null,
-                        "releaseTag": null,
+                        "releaseDate": "2010-05-10",
+                        "releaseID": "ocds-213czf-000-00001-05-contract",
+                        "releaseTag": [
+                           "contract"
+                        ],
                         "value": "A contract has been signed between the Council and AnyCorp Ltd for construction of new cycle lanes in the centre of town."
                      },
                      {
-                        "releaseDate": null,
-                        "releaseID": null,
-                        "releaseTag": null,
+                        "releaseDate": "2011-01-10",
+                        "releaseID": "ocds-213czf-000-00001-06-implementation",
+                        "releaseTag": [
+                           "implementation"
+                        ],
                         "value": "Contract monitoring for cycle lane construction."
                      }
                   ],
@@ -887,58 +979,72 @@
                      {
                         "datePublished": [
                            {
-                              "releaseDate": null,
-                              "releaseID": null,
-                              "releaseTag": null,
+                              "releaseDate": "2010-05-10",
+                              "releaseID": "ocds-213czf-000-00001-05-contract",
+                              "releaseTag": [
+                                 "contract"
+                              ],
                               "value": "2015-06-10"
                            }
                         ],
                         "description": [
                            {
-                              "releaseDate": null,
-                              "releaseID": null,
-                              "releaseTag": null,
+                              "releaseDate": "2010-05-10",
+                              "releaseID": "ocds-213czf-000-00001-05-contract",
+                              "releaseTag": [
+                                 "contract"
+                              ],
                               "value": "The Signed Contract for Cycle Path Construction"
                            }
                         ],
                         "documentType": [
                            {
-                              "releaseDate": null,
-                              "releaseID": null,
-                              "releaseTag": null,
+                              "releaseDate": "2010-05-10",
+                              "releaseID": "ocds-213czf-000-00001-05-contract",
+                              "releaseTag": [
+                                 "contract"
+                              ],
                               "value": "contractSigned"
                            }
                         ],
                         "format": [
                            {
-                              "releaseDate": null,
-                              "releaseID": null,
-                              "releaseTag": null,
+                              "releaseDate": "2010-05-10",
+                              "releaseID": "ocds-213czf-000-00001-05-contract",
+                              "releaseTag": [
+                                 "contract"
+                              ],
                               "value": "application/pdf"
                            }
                         ],
                         "id": "0008",
                         "language": [
                            {
-                              "releaseDate": null,
-                              "releaseID": null,
-                              "releaseTag": null,
+                              "releaseDate": "2010-05-10",
+                              "releaseID": "ocds-213czf-000-00001-05-contract",
+                              "releaseTag": [
+                                 "contract"
+                              ],
                               "value": "en"
                            }
                         ],
                         "title": [
                            {
-                              "releaseDate": null,
-                              "releaseID": null,
-                              "releaseTag": null,
+                              "releaseDate": "2010-05-10",
+                              "releaseID": "ocds-213czf-000-00001-05-contract",
+                              "releaseTag": [
+                                 "contract"
+                              ],
                               "value": "Signed Contract"
                            }
                         ],
                         "url": [
                            {
-                              "releaseDate": null,
-                              "releaseID": null,
-                              "releaseTag": null,
+                              "releaseDate": "2010-05-10",
+                              "releaseID": "ocds-213czf-000-00001-05-contract",
+                              "releaseTag": [
+                                 "contract"
+                              ],
                               "value": "http://example.com/contracts/ocds-213czf-000-00001"
                            }
                         ]
@@ -946,58 +1052,72 @@
                      {
                         "datePublished": [
                            {
-                              "releaseDate": null,
-                              "releaseID": null,
-                              "releaseTag": null,
+                              "releaseDate": "2011-01-10",
+                              "releaseID": "ocds-213czf-000-00001-06-implementation",
+                              "releaseTag": [
+                                 "implementation"
+                              ],
                               "value": "2010-12-15"
                            }
                         ],
                         "description": [
                            {
-                              "releaseDate": null,
-                              "releaseID": null,
-                              "releaseTag": null,
+                              "releaseDate": "2011-01-10",
+                              "releaseID": "ocds-213czf-000-00001-06-implementation",
+                              "releaseTag": [
+                                 "implementation"
+                              ],
                               "value": "Physical progress report for cycle path construction"
                            }
                         ],
                         "documentType": [
                            {
-                              "releaseDate": null,
-                              "releaseID": null,
-                              "releaseTag": null,
+                              "releaseDate": "2011-01-10",
+                              "releaseID": "ocds-213czf-000-00001-06-implementation",
+                              "releaseTag": [
+                                 "implementation"
+                              ],
                               "value": "physicalProcessReport"
                            }
                         ],
                         "format": [
                            {
-                              "releaseDate": null,
-                              "releaseID": null,
-                              "releaseTag": null,
+                              "releaseDate": "2011-01-10",
+                              "releaseID": "ocds-213czf-000-00001-06-implementation",
+                              "releaseTag": [
+                                 "implementation"
+                              ],
                               "value": "application/pdf"
                            }
                         ],
                         "id": "0009",
                         "language": [
                            {
-                              "releaseDate": null,
-                              "releaseID": null,
-                              "releaseTag": null,
+                              "releaseDate": "2011-01-10",
+                              "releaseID": "ocds-213czf-000-00001-06-implementation",
+                              "releaseTag": [
+                                 "implementation"
+                              ],
                               "value": "en"
                            }
                         ],
                         "title": [
                            {
-                              "releaseDate": null,
-                              "releaseID": null,
-                              "releaseTag": null,
+                              "releaseDate": "2011-01-10",
+                              "releaseID": "ocds-213czf-000-00001-06-implementation",
+                              "releaseTag": [
+                                 "implementation"
+                              ],
                               "value": "Progress report"
                            }
                         ],
                         "url": [
                            {
-                              "releaseDate": null,
-                              "releaseID": null,
-                              "releaseTag": null,
+                              "releaseDate": "2011-01-10",
+                              "releaseID": "ocds-213czf-000-00001-06-implementation",
+                              "releaseTag": [
+                                 "implementation"
+                              ],
                               "value": "http://example.com/reports/ocds-213czf-000-00001/cycle-path-01.pdf"
                            }
                         ]
@@ -1010,38 +1130,48 @@
                            "amount": {
                               "amount": [
                                  {
-                                    "releaseDate": null,
-                                    "releaseID": null,
-                                    "releaseTag": null,
+                                    "releaseDate": "2011-01-10",
+                                    "releaseID": "ocds-213czf-000-00001-06-implementation",
+                                    "releaseTag": [
+                                       "implementation"
+                                    ],
                                     "value": 500000
                                  },
                                  {
-                                    "releaseDate": null,
-                                    "releaseID": null,
-                                    "releaseTag": null,
+                                    "releaseDate": "2011-01-10",
+                                    "releaseID": "ocds-213czf-000-00001-06-implementation",
+                                    "releaseTag": [
+                                       "implementation"
+                                    ],
                                     "value": 100000
                                  }
                               ],
                               "currency": [
                                  {
-                                    "releaseDate": null,
-                                    "releaseID": null,
-                                    "releaseTag": null,
+                                    "releaseDate": "2011-01-10",
+                                    "releaseID": "ocds-213czf-000-00001-06-implementation",
+                                    "releaseTag": [
+                                       "implementation"
+                                    ],
                                     "value": "GBP"
                                  }
                               ]
                            },
                            "date": [
                               {
-                                 "releaseDate": null,
-                                 "releaseID": null,
-                                 "releaseTag": null,
+                                 "releaseDate": "2011-01-10",
+                                 "releaseID": "ocds-213czf-000-00001-06-implementation",
+                                 "releaseTag": [
+                                    "implementation"
+                                 ],
                                  "value": "2010-08-01"
                               },
                               {
-                                 "releaseDate": null,
-                                 "releaseID": null,
-                                 "releaseTag": null,
+                                 "releaseDate": "2011-01-10",
+                                 "releaseID": "ocds-213czf-000-00001-06-implementation",
+                                 "releaseTag": [
+                                    "implementation"
+                                 ],
                                  "value": "2010-10-01"
                               }
                            ],
@@ -1049,33 +1179,41 @@
                            "providerOrganization": {
                               "id": [
                                  {
-                                    "releaseDate": null,
-                                    "releaseID": null,
-                                    "releaseTag": null,
+                                    "releaseDate": "2011-01-10",
+                                    "releaseID": "ocds-213czf-000-00001-06-implementation",
+                                    "releaseTag": [
+                                       "implementation"
+                                    ],
                                     "value": "E09000003"
                                  }
                               ],
                               "legalName": [
                                  {
-                                    "releaseDate": null,
-                                    "releaseID": null,
-                                    "releaseTag": null,
+                                    "releaseDate": "2011-01-10",
+                                    "releaseID": "ocds-213czf-000-00001-06-implementation",
+                                    "releaseTag": [
+                                       "implementation"
+                                    ],
                                     "value": "London Borough of Barnet"
                                  }
                               ],
                               "scheme": [
                                  {
-                                    "releaseDate": null,
-                                    "releaseID": null,
-                                    "releaseTag": null,
+                                    "releaseDate": "2011-01-10",
+                                    "releaseID": "ocds-213czf-000-00001-06-implementation",
+                                    "releaseTag": [
+                                       "implementation"
+                                    ],
                                     "value": "GB-LAC"
                                  }
                               ],
                               "uri": [
                                  {
-                                    "releaseDate": null,
-                                    "releaseID": null,
-                                    "releaseTag": null,
+                                    "releaseDate": "2011-01-10",
+                                    "releaseID": "ocds-213czf-000-00001-06-implementation",
+                                    "releaseTag": [
+                                       "implementation"
+                                    ],
                                     "value": "http://www.barnet.gov.uk/"
                                  }
                               ]
@@ -1083,56 +1221,70 @@
                            "receiverOrganization": {
                               "id": [
                                  {
-                                    "releaseDate": null,
-                                    "releaseID": null,
-                                    "releaseTag": null,
+                                    "releaseDate": "2011-01-10",
+                                    "releaseID": "ocds-213czf-000-00001-06-implementation",
+                                    "releaseTag": [
+                                       "implementation"
+                                    ],
                                     "value": "1234567844"
                                  }
                               ],
                               "legalName": [
                                  {
-                                    "releaseDate": null,
-                                    "releaseID": null,
-                                    "releaseTag": null,
+                                    "releaseDate": "2011-01-10",
+                                    "releaseID": "ocds-213czf-000-00001-06-implementation",
+                                    "releaseTag": [
+                                       "implementation"
+                                    ],
                                     "value": "AnyCorp Ltd"
                                  }
                               ],
                               "scheme": [
                                  {
-                                    "releaseDate": null,
-                                    "releaseID": null,
-                                    "releaseTag": null,
+                                    "releaseDate": "2011-01-10",
+                                    "releaseID": "ocds-213czf-000-00001-06-implementation",
+                                    "releaseTag": [
+                                       "implementation"
+                                    ],
                                     "value": "GB-COH"
                                  }
                               ],
                               "uri": [
                                  {
-                                    "releaseDate": null,
-                                    "releaseID": null,
-                                    "releaseTag": null,
+                                    "releaseDate": "2011-01-10",
+                                    "releaseID": "ocds-213czf-000-00001-06-implementation",
+                                    "releaseTag": [
+                                       "implementation"
+                                    ],
                                     "value": "http://www.anycorp.example"
                                  }
                               ]
                            },
                            "source": [
                               {
-                                 "releaseDate": null,
-                                 "releaseID": null,
-                                 "releaseTag": null,
+                                 "releaseDate": "2011-01-10",
+                                 "releaseID": "ocds-213czf-000-00001-06-implementation",
+                                 "releaseTag": [
+                                    "implementation"
+                                 ],
                                  "value": "https://openspending.org/uk-barnet-spending/"
                               }
                            ],
                            "uri": [
                               {
-                                 "releaseDate": null,
-                                 "releaseID": null,
-                                 "releaseTag": null,
+                                 "releaseDate": "2011-01-10",
+                                 "releaseID": "ocds-213czf-000-00001-06-implementation",
+                                 "releaseTag": [
+                                    "implementation"
+                                 ],
                                  "value": "https://openspending.org/uk-barnet-spending/transaction/asd9235qaghvs1059620ywhgai"
                               },
                               {
-                                 "releaseDate": null,
-                                 "releaseID": null,
-                                 "releaseTag": null,
+                                 "releaseDate": "2011-01-10",
+                                 "releaseID": "ocds-213czf-000-00001-06-implementation",
+                                 "releaseTag": [
+                                    "implementation"
+                                 ],
                                  "value": "https://openspending.org/uk-barnet-spending/transaction/asd9235qaghvs105962as0012"
                               }
                            ]
@@ -1143,9 +1295,11 @@
                      {
                         "additionalClassifications": [
                            {
-                              "releaseDate": null,
-                              "releaseID": null,
-                              "releaseTag": null,
+                              "releaseDate": "2010-05-10",
+                              "releaseID": "ocds-213czf-000-00001-05-contract",
+                              "releaseTag": [
+                                 "contract"
+                              ],
                               "value": [
                                  {
                                     "description": "Cycle path construction work",
@@ -1159,77 +1313,95 @@
                         "classification": {
                            "description": [
                               {
-                                 "releaseDate": null,
-                                 "releaseID": null,
-                                 "releaseTag": null,
+                                 "releaseDate": "2010-05-10",
+                                 "releaseID": "ocds-213czf-000-00001-05-contract",
+                                 "releaseTag": [
+                                    "contract"
+                                 ],
                                  "value": "Construction work for highways"
                               }
                            ],
                            "id": [
                               {
-                                 "releaseDate": null,
-                                 "releaseID": null,
-                                 "releaseTag": null,
+                                 "releaseDate": "2010-05-10",
+                                 "releaseID": "ocds-213czf-000-00001-05-contract",
+                                 "releaseTag": [
+                                    "contract"
+                                 ],
                                  "value": "45233130"
                               }
                            ],
                            "scheme": [
                               {
-                                 "releaseDate": null,
-                                 "releaseID": null,
-                                 "releaseTag": null,
+                                 "releaseDate": "2010-05-10",
+                                 "releaseID": "ocds-213czf-000-00001-05-contract",
+                                 "releaseTag": [
+                                    "contract"
+                                 ],
                                  "value": "CPV"
                               }
                            ],
                            "uri": [
                               {
-                                 "releaseDate": null,
-                                 "releaseID": null,
-                                 "releaseTag": null,
+                                 "releaseDate": "2010-05-10",
+                                 "releaseID": "ocds-213czf-000-00001-05-contract",
+                                 "releaseTag": [
+                                    "contract"
+                                 ],
                                  "value": "http://cpv.data.ac.uk/code-45233130"
                               }
                            ]
                         },
                         "description": [
                            {
-                              "releaseDate": null,
-                              "releaseID": null,
-                              "releaseTag": null,
+                              "releaseDate": "2010-05-10",
+                              "releaseID": "ocds-213czf-000-00001-05-contract",
+                              "releaseTag": [
+                                 "contract"
+                              ],
                               "value": "string"
                            }
                         ],
                         "id": "0001",
                         "quantity": [
                            {
-                              "releaseDate": null,
-                              "releaseID": null,
-                              "releaseTag": null,
+                              "releaseDate": "2010-05-10",
+                              "releaseID": "ocds-213czf-000-00001-05-contract",
+                              "releaseTag": [
+                                 "contract"
+                              ],
                               "value": 8
                            }
                         ],
                         "unit": {
                            "name": [
                               {
-                                 "releaseDate": null,
-                                 "releaseID": null,
-                                 "releaseTag": null,
+                                 "releaseDate": "2010-05-10",
+                                 "releaseID": "ocds-213czf-000-00001-05-contract",
+                                 "releaseTag": [
+                                    "contract"
+                                 ],
                                  "value": "Miles"
                               }
                            ],
                            "value": {
                               "amount": [
                                  {
-                                    "releaseDate": null,
-                                    "releaseID": null,
-                                    "releaseTag": null,
+                                    "releaseDate": "2010-05-10",
+                                    "releaseID": "ocds-213czf-000-00001-05-contract",
+                                    "releaseTag": [
+                                       "contract"
+                                    ],
                                     "value": 137000
                                  }
                               ],
                               "currency": [
                                  {
-                                    "releaseDate": null,
-                                    "releaseID": null,
-                                    "releaseTag": null,
+                                    "releaseDate": "2010-05-10",
+                                    "releaseID": "ocds-213czf-000-00001-05-contract",
+                                    "releaseTag": [
+                                       "contract"
+                                    ],
                                     "value": "GBP"
                                  }
                               ]
@@ -1240,51 +1412,63 @@
                   "period": {
                      "endDate": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2010-05-10",
+                           "releaseID": "ocds-213czf-000-00001-05-contract",
+                           "releaseTag": [
+                              "contract"
+                           ],
                            "value": "2011-08-01"
                         }
                      ],
                      "startDate": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2010-05-10",
+                           "releaseID": "ocds-213czf-000-00001-05-contract",
+                           "releaseTag": [
+                              "contract"
+                           ],
                            "value": "2010-07-01"
                         }
                      ]
                   },
                   "status": [
                      {
-                        "releaseDate": null,
-                        "releaseID": null,
-                        "releaseTag": null,
+                        "releaseDate": "2010-05-10",
+                        "releaseID": "ocds-213czf-000-00001-05-contract",
+                        "releaseTag": [
+                           "contract"
+                        ],
                         "value": "active"
                      }
                   ],
                   "title": [
                      {
-                        "releaseDate": null,
-                        "releaseID": null,
-                        "releaseTag": null,
+                        "releaseDate": "2010-05-10",
+                        "releaseID": "ocds-213czf-000-00001-05-contract",
+                        "releaseTag": [
+                           "contract"
+                        ],
                         "value": "Contract to build new cycle lanes in the centre of town."
                      }
                   ],
                   "value": {
                      "amount": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2010-05-10",
+                           "releaseID": "ocds-213czf-000-00001-05-contract",
+                           "releaseTag": [
+                              "contract"
+                           ],
                            "value": 11000000
                         }
                      ],
                      "currency": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2010-05-10",
+                           "releaseID": "ocds-213czf-000-00001-05-contract",
+                           "releaseTag": [
+                              "contract"
+                           ],
                            "value": "GBP"
                         }
                      ]
@@ -1295,17 +1479,21 @@
             "id": null,
             "initiationType": [
                {
-                  "releaseDate": null,
-                  "releaseID": null,
-                  "releaseTag": null,
+                  "releaseDate": "2009-03-15",
+                  "releaseID": "ocds-213czf-000-00001-01-planning",
+                  "releaseTag": [
+                     "planning"
+                  ],
                   "value": "tender"
                }
             ],
             "language": [
                {
-                  "releaseDate": null,
-                  "releaseID": null,
-                  "releaseTag": null,
+                  "releaseDate": "2009-03-15",
+                  "releaseID": "ocds-213czf-000-00001-01-planning",
+                  "releaseTag": [
+                     "planning"
+                  ],
                   "value": "en"
                }
             ],
@@ -1313,9 +1501,11 @@
             "planning": {
                "budget": [
                   {
-                     "releaseDate": null,
-                     "releaseID": null,
-                     "releaseTag": null,
+                     "releaseDate": "2009-03-15",
+                     "releaseID": "ocds-213czf-000-00001-01-planning",
+                     "releaseTag": [
+                        "planning"
+                     ],
                      "value": {
                         "amount": {
                            "amount": 6700000.0,
@@ -1334,58 +1524,72 @@
                   {
                      "datePublished": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "2009-01-05"
                         }
                      ],
                      "description": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "The overall strategic framework for procurement to enhance cycle provision."
                         }
                      ],
                      "documentType": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "procurementPlan"
                         }
                      ],
                      "format": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "application/pdf"
                         }
                      ],
                      "id": "0001",
                      "language": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "en"
                         }
                      ],
                      "title": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "Area Wide Cycle Improvements - Procurement Plan"
                         }
                      ],
                      "url": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "http://example.com/opencontracting/documents/planning/highways/procurementPlan.pdf"
                         }
                      ]
@@ -1393,58 +1597,72 @@
                   {
                      "datePublished": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "2009-01-15"
                         }
                      ],
                      "description": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "Needs assessment for provision for cyclists in the centre of town."
                         }
                      ],
                      "documentType": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "needsAssessment"
                         }
                      ],
                      "format": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "application/pdf"
                         }
                      ],
                      "id": "0002",
                      "language": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "en"
                         }
                      ],
                      "title": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "Cycle provision - Needs Assessment"
                         }
                      ],
                      "url": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "http://example.com/opencontracting/documents/ocds-213czf-000-00001/needsAssessment.pdf"
                         }
                      ]
@@ -1452,9 +1670,11 @@
                ],
                "rationale": [
                   {
-                     "releaseDate": null,
-                     "releaseID": null,
-                     "releaseTag": null,
+                     "releaseDate": "2009-03-15",
+                     "releaseID": "ocds-213czf-000-00001-01-planning",
+                     "releaseTag": [
+                        "planning"
+                     ],
                      "value": "The 2009 Strategic Plan identifies a need for an improved cycle route in the centre of town."
                   }
                ]
@@ -1464,9 +1684,11 @@
                "amendment": {
                   "changes": [
                      {
-                        "releaseDate": null,
-                        "releaseID": null,
-                        "releaseTag": null,
+                        "releaseDate": "2010-03-20",
+                        "releaseID": "ocds-213czf-000-00001-03-tenderAmendment",
+                        "releaseTag": [
+                           "tenderAmendment"
+                        ],
                         "value": [
                            {
                               "property": "documents"
@@ -1479,72 +1701,90 @@
                   ],
                   "date": [
                      {
-                        "releaseDate": null,
-                        "releaseID": null,
-                        "releaseTag": null,
+                        "releaseDate": "2010-03-20",
+                        "releaseID": "ocds-213czf-000-00001-03-tenderAmendment",
+                        "releaseTag": [
+                           "tenderAmendment"
+                        ],
                         "value": "2010-03-20"
                      }
                   ],
                   "rationale": [
                      {
-                        "releaseDate": null,
-                        "releaseID": null,
-                        "releaseTag": null,
+                        "releaseDate": "2010-03-20",
+                        "releaseID": "ocds-213czf-000-00001-03-tenderAmendment",
+                        "releaseTag": [
+                           "tenderAmendment"
+                        ],
                         "value": "Following the enquiry period, enquiries were received and responses to questions asked have been published. No changes to the overall tender details were made."
                      }
                   ]
                },
                "awardCriteria": [
                   {
-                     "releaseDate": null,
-                     "releaseID": null,
-                     "releaseTag": null,
+                     "releaseDate": "2009-03-15",
+                     "releaseID": "ocds-213czf-000-00001-01-planning",
+                     "releaseTag": [
+                        "planning"
+                     ],
                      "value": "bestProposal"
                   }
                ],
                "awardCriteriaDetails": [
                   {
-                     "releaseDate": null,
-                     "releaseID": null,
-                     "releaseTag": null,
+                     "releaseDate": "2009-03-15",
+                     "releaseID": "ocds-213czf-000-00001-01-planning",
+                     "releaseTag": [
+                        "planning"
+                     ],
                      "value": "The best proposal, subject to value for money requirements, will be accepted."
                   }
                ],
                "awardPeriod": {
                   "endDate": [
                      {
-                        "releaseDate": null,
-                        "releaseID": null,
-                        "releaseTag": null,
+                        "releaseDate": "2009-03-15",
+                        "releaseID": "ocds-213czf-000-00001-01-planning",
+                        "releaseTag": [
+                           "planning"
+                        ],
                         "value": "2011-06-01"
                      },
                      {
-                        "releaseDate": null,
-                        "releaseID": null,
-                        "releaseTag": null,
+                        "releaseDate": "2010-03-15",
+                        "releaseID": "ocds-213czf-000-00001-02-tender",
+                        "releaseTag": [
+                           "tender"
+                        ],
                         "value": "2011-08-01"
                      }
                   ],
                   "startDate": [
                      {
-                        "releaseDate": null,
-                        "releaseID": null,
-                        "releaseTag": null,
+                        "releaseDate": "2009-03-15",
+                        "releaseID": "ocds-213czf-000-00001-01-planning",
+                        "releaseTag": [
+                           "planning"
+                        ],
                         "value": "2010-06-01"
                      }
                   ]
                },
                "description": [
                   {
-                     "releaseDate": null,
-                     "releaseID": null,
-                     "releaseTag": null,
+                     "releaseDate": "2009-03-15",
+                     "releaseID": "ocds-213czf-000-00001-01-planning",
+                     "releaseTag": [
+                        "planning"
+                     ],
                      "value": "The authority plans to tender for improvements to the cycle lane in early 2010. This notice provides advanced notice of the intention to tender, and details to upcoming consultation events."
                   },
                   {
-                     "releaseDate": null,
-                     "releaseID": null,
-                     "releaseTag": null,
+                     "releaseDate": "2010-03-15",
+                     "releaseID": "ocds-213czf-000-00001-02-tender",
+                     "releaseTag": [
+                        "tender"
+                     ],
                      "value": "Tenders solicited for work to build new cycle lanes in the centre of town."
                   }
                ],
@@ -1552,66 +1792,82 @@
                   {
                      "dateModified": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "2015-02-15"
                         }
                      ],
                      "datePublished": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "2015-02-15"
                         }
                      ],
                      "description": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "A consultation document inviting citizen input into cycle provision."
                         }
                      ],
                      "documentType": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "x_consultationDocument"
                         }
                      ],
                      "format": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "text/html"
                         }
                      ],
                      "id": "0003",
                      "language": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "en"
                         }
                      ],
                      "title": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "Consultation on cycle provision"
                         }
                      ],
                      "url": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "http://example.com/consultations/cycle-provision/"
                         }
                      ]
@@ -1619,50 +1875,62 @@
                   {
                      "datePublished": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "2015-02-15"
                         }
                      ],
                      "description": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "A map showing areas affected by the planned highway updates. Available from local libraries."
                         }
                      ],
                      "documentType": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "x_map"
                         }
                      ],
                      "format": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "offline/print"
                         }
                      ],
                      "id": "0004",
                      "language": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "en"
                         }
                      ],
                      "title": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "Map of affected areas"
                         }
                      ]
@@ -1670,58 +1938,72 @@
                   {
                      "datePublished": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2010-03-15",
+                           "releaseID": "ocds-213czf-000-00001-02-tender",
+                           "releaseTag": [
+                              "tender"
+                           ],
                            "value": "2010-03-01"
                         }
                      ],
                      "description": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2010-03-15",
+                           "releaseID": "ocds-213czf-000-00001-02-tender",
+                           "releaseTag": [
+                              "tender"
+                           ],
                            "value": "Official tender notice."
                         }
                      ],
                      "documentType": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2010-03-15",
+                           "releaseID": "ocds-213czf-000-00001-02-tender",
+                           "releaseTag": [
+                              "tender"
+                           ],
                            "value": "notice"
                         }
                      ],
                      "format": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2010-03-15",
+                           "releaseID": "ocds-213czf-000-00001-02-tender",
+                           "releaseTag": [
+                              "tender"
+                           ],
                            "value": "text/html"
                         }
                      ],
                      "id": "0005",
                      "language": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2010-03-15",
+                           "releaseID": "ocds-213czf-000-00001-02-tender",
+                           "releaseTag": [
+                              "tender"
+                           ],
                            "value": "en"
                         }
                      ],
                      "title": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2010-03-15",
+                           "releaseID": "ocds-213czf-000-00001-02-tender",
+                           "releaseTag": [
+                              "tender"
+                           ],
                            "value": "Tender Notice"
                         }
                      ],
                      "url": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2010-03-15",
+                           "releaseID": "ocds-213czf-000-00001-02-tender",
+                           "releaseTag": [
+                              "tender"
+                           ],
                            "value": "http://example.com/tender-notices/ocds-213czf-000-00001-01.html"
                         }
                      ]
@@ -1729,58 +2011,72 @@
                   {
                      "datePublished": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2010-03-20",
+                           "releaseID": "ocds-213czf-000-00001-03-tenderAmendment",
+                           "releaseTag": [
+                              "tenderAmendment"
+                           ],
                            "value": "2010-03-20"
                         }
                      ],
                      "description": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2010-03-20",
+                           "releaseID": "ocds-213czf-000-00001-03-tenderAmendment",
+                           "releaseTag": [
+                              "tenderAmendment"
+                           ],
                            "value": "Responses to enquiries asked by interested parties."
                         }
                      ],
                      "documentType": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2010-03-20",
+                           "releaseID": "ocds-213czf-000-00001-03-tenderAmendment",
+                           "releaseTag": [
+                              "tenderAmendment"
+                           ],
                            "value": "enquiryResponses"
                         }
                      ],
                      "format": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2010-03-20",
+                           "releaseID": "ocds-213czf-000-00001-03-tenderAmendment",
+                           "releaseTag": [
+                              "tenderAmendment"
+                           ],
                            "value": "text/html"
                         }
                      ],
                      "id": "0006",
                      "language": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2010-03-20",
+                           "releaseID": "ocds-213czf-000-00001-03-tenderAmendment",
+                           "releaseTag": [
+                              "tenderAmendment"
+                           ],
                            "value": "en"
                         }
                      ],
                      "title": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2010-03-20",
+                           "releaseID": "ocds-213czf-000-00001-03-tenderAmendment",
+                           "releaseTag": [
+                              "tenderAmendment"
+                           ],
                            "value": "Enquiry Responses"
                         }
                      ],
                      "url": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2010-03-20",
+                           "releaseID": "ocds-213czf-000-00001-03-tenderAmendment",
+                           "releaseTag": [
+                              "tenderAmendment"
+                           ],
                            "value": "http://example.com/enquiry-response/ocds-213czf-000-00001-01.html"
                         }
                      ]
@@ -1789,46 +2085,58 @@
                "enquiryPeriod": {
                   "endDate": [
                      {
-                        "releaseDate": null,
-                        "releaseID": null,
-                        "releaseTag": null,
+                        "releaseDate": "2010-03-15",
+                        "releaseID": "ocds-213czf-000-00001-02-tender",
+                        "releaseTag": [
+                           "tender"
+                        ],
                         "value": "2010-03-14"
                      }
                   ],
                   "startDate": [
                      {
-                        "releaseDate": null,
-                        "releaseID": null,
-                        "releaseTag": null,
+                        "releaseDate": "2010-03-15",
+                        "releaseID": "ocds-213czf-000-00001-02-tender",
+                        "releaseTag": [
+                           "tender"
+                        ],
                         "value": "2010-03-01"
                      }
                   ]
                },
                "hasEnquiries": [
                   {
-                     "releaseDate": null,
-                     "releaseID": null,
-                     "releaseTag": null,
+                     "releaseDate": "2010-03-15",
+                     "releaseID": "ocds-213czf-000-00001-02-tender",
+                     "releaseTag": [
+                        "tender"
+                     ],
                      "value": false
                   },
                   {
-                     "releaseDate": null,
-                     "releaseID": null,
-                     "releaseTag": null,
+                     "releaseDate": "2010-03-20",
+                     "releaseID": "ocds-213czf-000-00001-03-tenderAmendment",
+                     "releaseTag": [
+                        "tenderAmendment"
+                     ],
                      "value": true
                   }
                ],
                "id": [
                   {
-                     "releaseDate": null,
-                     "releaseID": null,
-                     "releaseTag": null,
+                     "releaseDate": "2009-03-15",
+                     "releaseID": "ocds-213czf-000-00001-01-planning",
+                     "releaseTag": [
+                        "planning"
+                     ],
                      "value": "ocds-213czf-000-00001-01-planning"
                   },
                   {
-                     "releaseDate": null,
-                     "releaseID": null,
-                     "releaseTag": null,
+                     "releaseDate": "2010-03-15",
+                     "releaseID": "ocds-213czf-000-00001-02-tender",
+                     "releaseTag": [
+                        "tender"
+                     ],
                      "value": "ocds-213czf-000-00001-01-tender"
                   }
                ],
@@ -1836,9 +2144,11 @@
                   {
                      "additionalClassifications": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": [
                               {
                                  "description": "Cycle path construction work",
@@ -1852,89 +2162,111 @@
                      "classification": {
                         "description": [
                            {
-                              "releaseDate": null,
-                              "releaseID": null,
-                              "releaseTag": null,
+                              "releaseDate": "2009-03-15",
+                              "releaseID": "ocds-213czf-000-00001-01-planning",
+                              "releaseTag": [
+                                 "planning"
+                              ],
                               "value": "Construction work for highways"
                            }
                         ],
                         "id": [
                            {
-                              "releaseDate": null,
-                              "releaseID": null,
-                              "releaseTag": null,
+                              "releaseDate": "2009-03-15",
+                              "releaseID": "ocds-213czf-000-00001-01-planning",
+                              "releaseTag": [
+                                 "planning"
+                              ],
                               "value": "45233130"
                            }
                         ],
                         "scheme": [
                            {
-                              "releaseDate": null,
-                              "releaseID": null,
-                              "releaseTag": null,
+                              "releaseDate": "2009-03-15",
+                              "releaseID": "ocds-213czf-000-00001-01-planning",
+                              "releaseTag": [
+                                 "planning"
+                              ],
                               "value": "CPV"
                            }
                         ],
                         "uri": [
                            {
-                              "releaseDate": null,
-                              "releaseID": null,
-                              "releaseTag": null,
+                              "releaseDate": "2009-03-15",
+                              "releaseID": "ocds-213czf-000-00001-01-planning",
+                              "releaseTag": [
+                                 "planning"
+                              ],
                               "value": "http://cpv.data.ac.uk/code-45233130"
                            }
                         ]
                      },
                      "description": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "string"
                         }
                      ],
                      "id": "0001",
                      "quantity": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": 10
                         },
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2010-03-15",
+                           "releaseID": "ocds-213czf-000-00001-02-tender",
+                           "releaseTag": [
+                              "tender"
+                           ],
                            "value": 8
                         }
                      ],
                      "unit": {
                         "name": [
                            {
-                              "releaseDate": null,
-                              "releaseID": null,
-                              "releaseTag": null,
+                              "releaseDate": "2009-03-15",
+                              "releaseID": "ocds-213czf-000-00001-01-planning",
+                              "releaseTag": [
+                                 "planning"
+                              ],
                               "value": "Miles"
                            }
                         ],
                         "value": {
                            "amount": [
                               {
-                                 "releaseDate": null,
-                                 "releaseID": null,
-                                 "releaseTag": null,
+                                 "releaseDate": "2009-03-15",
+                                 "releaseID": "ocds-213czf-000-00001-01-planning",
+                                 "releaseTag": [
+                                    "planning"
+                                 ],
                                  "value": 100000
                               },
                               {
-                                 "releaseDate": null,
-                                 "releaseID": null,
-                                 "releaseTag": null,
+                                 "releaseDate": "2010-03-15",
+                                 "releaseID": "ocds-213czf-000-00001-02-tender",
+                                 "releaseTag": [
+                                    "tender"
+                                 ],
                                  "value": 120000
                               }
                            ],
                            "currency": [
                               {
-                                 "releaseDate": null,
-                                 "releaseID": null,
-                                 "releaseTag": null,
+                                 "releaseDate": "2009-03-15",
+                                 "releaseID": "ocds-213czf-000-00001-01-planning",
+                                 "releaseTag": [
+                                    "planning"
+                                 ],
                                  "value": "GBP"
                               }
                            ]
@@ -1946,26 +2278,32 @@
                   {
                      "description": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "A consultation period is open for citizen input to shape the final plans."
                         }
                      ],
                      "dueDate": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "2015=04-15"
                         }
                      ],
                      "id": "0001",
                      "title": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "Consultation Period"
                         }
                      ]
@@ -1974,40 +2312,50 @@
                "minValue": {
                   "amount": [
                      {
-                        "releaseDate": null,
-                        "releaseID": null,
-                        "releaseTag": null,
+                        "releaseDate": "2009-03-15",
+                        "releaseID": "ocds-213czf-000-00001-01-planning",
+                        "releaseTag": [
+                           "planning"
+                        ],
                         "value": 500000
                      },
                      {
-                        "releaseDate": null,
-                        "releaseID": null,
-                        "releaseTag": null,
+                        "releaseDate": "2010-03-15",
+                        "releaseID": "ocds-213czf-000-00001-02-tender",
+                        "releaseTag": [
+                           "tender"
+                        ],
                         "value": 600000
                      }
                   ],
                   "currency": [
                      {
-                        "releaseDate": null,
-                        "releaseID": null,
-                        "releaseTag": null,
+                        "releaseDate": "2009-03-15",
+                        "releaseID": "ocds-213czf-000-00001-01-planning",
+                        "releaseTag": [
+                           "planning"
+                        ],
                         "value": "GBP"
                      }
                   ]
                },
                "procurementMethod": [
                   {
-                     "releaseDate": null,
-                     "releaseID": null,
-                     "releaseTag": null,
+                     "releaseDate": "2009-03-15",
+                     "releaseID": "ocds-213czf-000-00001-01-planning",
+                     "releaseTag": [
+                        "planning"
+                     ],
                      "value": "open"
                   }
                ],
                "procurementMethodRationale": [
                   {
-                     "releaseDate": null,
-                     "releaseID": null,
-                     "releaseTag": null,
+                     "releaseDate": "2009-03-15",
+                     "releaseID": "ocds-213czf-000-00001-01-planning",
+                     "releaseTag": [
+                        "planning"
+                     ],
                      "value": "An open competitive tender is required by EU Rules"
                   }
                ],
@@ -2015,41 +2363,51 @@
                   "address": {
                      "countryName": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "United Kingdom"
                         }
                      ],
                      "locality": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "London"
                         }
                      ],
                      "postalCode": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "N11 1NP"
                         }
                      ],
                      "region": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "London"
                         }
                      ],
                      "streetAddress": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "4, North London Business Park, Oakleigh Rd S"
                         }
                      ]
@@ -2057,41 +2415,51 @@
                   "contactPoint": {
                      "email": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "procurement-team@example.com"
                         }
                      ],
                      "faxNumber": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "01234 345 345"
                         }
                      ],
                      "name": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "Procurement Team"
                         }
                      ],
                      "telephone": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "01234 345 346"
                         }
                      ],
                      "url": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "http://example.com/contact/"
                         }
                      ]
@@ -2099,65 +2467,81 @@
                   "identifier": {
                      "id": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "E09000003"
                         }
                      ],
                      "legalName": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "London Borough of Barnet"
                         }
                      ],
                      "scheme": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "GB-LAC"
                         }
                      ],
                      "uri": [
                         {
-                           "releaseDate": null,
-                           "releaseID": null,
-                           "releaseTag": null,
+                           "releaseDate": "2009-03-15",
+                           "releaseID": "ocds-213czf-000-00001-01-planning",
+                           "releaseTag": [
+                              "planning"
+                           ],
                            "value": "http://www.barnet.gov.uk/"
                         }
                      ]
                   },
                   "name": [
                      {
-                        "releaseDate": null,
-                        "releaseID": null,
-                        "releaseTag": null,
+                        "releaseDate": "2009-03-15",
+                        "releaseID": "ocds-213czf-000-00001-01-planning",
+                        "releaseTag": [
+                           "planning"
+                        ],
                         "value": "London Borough of Barnet"
                      }
                   ]
                },
                "status": [
                   {
-                     "releaseDate": null,
-                     "releaseID": null,
-                     "releaseTag": null,
+                     "releaseDate": "2009-03-15",
+                     "releaseID": "ocds-213czf-000-00001-01-planning",
+                     "releaseTag": [
+                        "planning"
+                     ],
                      "value": "planned"
                   },
                   {
-                     "releaseDate": null,
-                     "releaseID": null,
-                     "releaseTag": null,
+                     "releaseDate": "2010-03-15",
+                     "releaseID": "ocds-213czf-000-00001-02-tender",
+                     "releaseTag": [
+                        "tender"
+                     ],
                      "value": "active"
                   }
                ],
                "submissionMethod": [
                   {
-                     "releaseDate": null,
-                     "releaseID": null,
-                     "releaseTag": null,
+                     "releaseDate": "2010-03-15",
+                     "releaseID": "ocds-213czf-000-00001-02-tender",
+                     "releaseTag": [
+                        "tender"
+                     ],
                      "value": [
                         "electronicSubmission"
                      ]
@@ -2165,64 +2549,80 @@
                ],
                "submissionMethodDetails": [
                   {
-                     "releaseDate": null,
-                     "releaseID": null,
-                     "releaseTag": null,
+                     "releaseDate": "2010-03-15",
+                     "releaseID": "ocds-213czf-000-00001-02-tender",
+                     "releaseTag": [
+                        "tender"
+                     ],
                      "value": "Submit through the online portal at http://example.com/submissions/ocds-213czf-000-00001-01/"
                   }
                ],
                "tenderPeriod": {
                   "endDate": [
                      {
-                        "releaseDate": null,
-                        "releaseID": null,
-                        "releaseTag": null,
+                        "releaseDate": "2010-03-15",
+                        "releaseID": "ocds-213czf-000-00001-02-tender",
+                        "releaseTag": [
+                           "tender"
+                        ],
                         "value": "2011-04-01"
                      }
                   ],
                   "startDate": [
                      {
-                        "releaseDate": null,
-                        "releaseID": null,
-                        "releaseTag": null,
+                        "releaseDate": "2009-03-15",
+                        "releaseID": "ocds-213czf-000-00001-01-planning",
+                        "releaseTag": [
+                           "planning"
+                        ],
                         "value": "2010-02-01"
                      },
                      {
-                        "releaseDate": null,
-                        "releaseID": null,
-                        "releaseTag": null,
+                        "releaseDate": "2010-03-15",
+                        "releaseID": "ocds-213czf-000-00001-02-tender",
+                        "releaseTag": [
+                           "tender"
+                        ],
                         "value": "2010-03-01"
                      }
                   ]
                },
                "title": [
                   {
-                     "releaseDate": null,
-                     "releaseID": null,
-                     "releaseTag": null,
+                     "releaseDate": "2009-03-15",
+                     "releaseID": "ocds-213czf-000-00001-01-planning",
+                     "releaseTag": [
+                        "planning"
+                     ],
                      "value": "Planned cycle lane improvements"
                   }
                ],
                "value": {
                   "amount": [
                      {
-                        "releaseDate": null,
-                        "releaseID": null,
-                        "releaseTag": null,
+                        "releaseDate": "2009-03-15",
+                        "releaseID": "ocds-213czf-000-00001-01-planning",
+                        "releaseTag": [
+                           "planning"
+                        ],
                         "value": 1000000
                      },
                      {
-                        "releaseDate": null,
-                        "releaseID": null,
-                        "releaseTag": null,
+                        "releaseDate": "2010-03-15",
+                        "releaseID": "ocds-213czf-000-00001-02-tender",
+                        "releaseTag": [
+                           "tender"
+                        ],
                         "value": 1100000
                      }
                   ],
                   "currency": [
                      {
-                        "releaseDate": null,
-                        "releaseID": null,
-                        "releaseTag": null,
+                        "releaseDate": "2009-03-15",
+                        "releaseID": "ocds-213czf-000-00001-01-planning",
+                        "releaseTag": [
+                           "planning"
+                        ],
                         "value": "GBP"
                      }
                   ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 jsonschema==2.5.1
--e git://github.com/open-contracting/jsonmerge.git@7d1506cef4a6de534ff6ebfaa4a412ffee771630#egg=jsonmerge
+-e git://github.com/open-contracting/jsonmerge.git@2b87eea10bed3aa380cb28034a96783ac3081a85#egg=jsonmerge


### PR DESCRIPTION
See: https://github.com/open-contracting/sample-data/blob/4e4e2541dfa43d3b3a809c0190288b95db4bbd7f/fictional-example/record/ocds-213czf-000-00001.json#L450

Note that this doesn't yet validate. The major problems it that `releaseTag` is an array, but the schema expects a string. I'm not sure how this is meant to work though, it may be a schema bug (and I think it's one @kindly has also identified).
