### PR TITLE
Move CRM documentation into readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 
 [![Build Status](https://travis-ci.org/open-contracting/sample-data.svg?branch=master)](https://travis-ci.org/open-contracting/sample-data)
 
-This repository holds sample data represented using the the new [Open Contracting Data Standard](http://ocds.open-contracting.org/standard/)
+This repository holds sample data represented using the [Open Contracting Data Standard](http://ocds.open-contracting.org/standard/). It includes the following types of sample data:
+
+* Fictional JSON and XLSX examples of releases and records, designed to demonstrate the key features of OCDS
+* Blank templates, designed to provide a reference JSON file including all of the fields in the OCDS schema
+* Flat templates, designed to provide a reference .csv and .xlsx files including all of the fields in OCDS
+* Real examples, a collection of scraper scripts and samples of releases and records from real OCDS implementations
 
 It should contain data aligned with the current version of the standard. Data aligned with previous versions of the standard may be found on named branches.
 

--- a/fictional-example/1.0/README.md
+++ b/fictional-example/1.0/README.md
@@ -1,3 +1,5 @@
 # Fictional example
 
 A work-in-progress fictional example designed to demonstrate the key features of OCDS.
+
+These examples were handwritten.

--- a/fictional-example/1.1/README.md
+++ b/fictional-example/1.1/README.md
@@ -1,3 +1,5 @@
 # Fictional example
 
 A work-in-progress fictional example designed to demonstrate the key features of OCDS.
+
+These examples were generated from the [OCDS 1.1 Sample Data Spreadsheet Input Template](https://docs.google.com/spreadsheets/d/1P-q5S8-WUxYT6t8uVuZDvnGfsl39DhhZV_GvgR1GKHk/edit#gid=159397949). To update the examples, edit the spreadsheet input template and export using the `exportIndividualReleases` Google Apps script associated with the spreadsheet. This generates the individual XLSX releases that can be converted into JSON using the OCDS Validator and merged into a record using the merge tool.


### PR DESCRIPTION
I copied over the explanations for `fictional-example` from the CRM, but I don't know if the CRM documentation is up-to-date.