### PR TITLE
Update jalisco script

### DIFF
--- a/real-examples/mexico/jalisco/fetch.py
+++ b/real-examples/mexico/jalisco/fetch.py
@@ -29,25 +29,23 @@ def main():
         package_urls = package_urls[:10]
     for url in package_urls:
         print('fetching', url)
-        data_array = common.getUrlAndRetry(url, folder)
-        for data in data_array:
-            if options.bigquery:
-                common.writeReleases(
-                    [data['records'][0]['compiledRelease']], folder, data, url, 'records')
-            else:
-                common.writeFile('%s.json' % str(data['uri'].split('/')[-1]), folder, data, url, 'records')
-            if options.releases:
-                for release_url in data['packages']:
-                    if count > 10 and not options.all:
-                        break
-                    print('fetching', release_url)
-                    releases = common.getUrlAndRetry(release_url, folder)
-                    for release in releases:
-                        count = count + 1
-                        if options.bigquery:
-                            common.writeReleases(release['releases'], folder, release, release_url)
-                        else:
-                            common.writeFile('%s.json' % str(release_url.split('/')[-1]), folder, release, release_url)
+        data = common.getUrlAndRetry(url, folder)
+        if options.bigquery:
+            common.writeReleases(
+                [data['records'][0]['compiledRelease']], folder, data, url, 'records')
+        else:
+            common.writeFile('%s.json' % str(data['uri'].split('/')[-1]), folder, data, url, 'records')
+        if options.releases:
+            for release_url in data['packages']:
+                if count > 10 and not options.all:
+                    break
+                print('fetching', release_url)
+                release = common.getUrlAndRetry(release_url, folder)
+                count = count + 1
+                if options.bigquery:
+                    common.writeReleases(release['releases'], folder, release, release_url)
+                else:
+                    common.writeFile('%s.json' % str(release_url.split('/')[-1]), folder, release, release_url)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Update Jalisco script because they updated their data to publish a single
record/release package instead of an array of them